### PR TITLE
Feat: Add buy-in tracking and enhance score calculation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -152,7 +152,9 @@ class _HomePageState extends State<HomePage> {
                 final session = _gameSessions[index];
                 // Format the date nicely
                 final formattedDate = DateFormat.yMMMd().add_jm().format(session.date);
-                final playersSummary = session.players.map((p) => '${p.name}: ${p.score}').join(', ');
+                final playersSummary = session.players
+                    .map((p) => '${p.name} / stack: ${p.stack}, buy-in: ${p.buyIn}, score: ${p.score}')
+                    .join('\n');
 
                 return Card(
                   margin: const EdgeInsets.symmetric(vertical: 6.0),

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -2,15 +2,20 @@ import 'package:flutter/foundation.dart';
 
 class Player {
   String name;
-  int score;
+  int stack;
+  int buyIn;
 
-  Player({required this.name, this.score = 0});
+  Player({required this.name, this.stack = 0, this.buyIn = 0});
+
+  // Calculated property for the score
+  int get score => stack - buyIn;
 
   // Factory constructor to create a Player from a JSON object
   factory Player.fromJson(Map<String, dynamic> json) {
     return Player(
       name: json['name'],
-      score: json['score'],
+      stack: json['stack'] ?? 0,
+      buyIn: json['buyIn'] ?? 0,
     );
   }
 
@@ -18,15 +23,17 @@ class Player {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'score': score,
+      'stack': stack,
+      'buyIn': buyIn,
     };
   }
 
   // Method to create a copy of a Player object
-  Player copyWith({String? name, int? score}) {
+  Player copyWith({String? name, int? stack, int? buyIn}) {
     return Player(
       name: name ?? this.name,
-      score: score ?? this.score,
+      stack: stack ?? this.stack,
+      buyIn: buyIn ?? this.buyIn,
     );
   }
 }


### PR DESCRIPTION
This commit introduces a buy-in tracking feature and updates the score calculation logic.

Key changes:
- The `Player` model is updated to include `stack` and `buyIn` fields. The `score` is now a calculated property (`stack - buyIn`).
- The score input screen is redesigned to have separate input fields for `stack` and `buy-in`, and it displays the real-time calculated score for each player.
- The totals for stack, buy-in, and score are displayed at the bottom of the input screen. The save button is only enabled when the total score is zero, ensuring the game balance.
- The home screen now displays a more detailed summary for each game session, including each player's stack, buy-in, and final score.