### PR TITLE
Fix: 新規プレイヤー追加時にオートコンプリートリストを更新

### DIFF
--- a/lib/screens/score_input_screen.dart
+++ b/lib/screens/score_input_screen.dart
@@ -55,6 +55,12 @@ class _ScoreInputScreenState extends State<ScoreInputScreen> {
       setState(() {
         final newPlayer = Player(name: playerName);
         _players.add(newPlayer);
+
+        // Add to all players list if not already there for autocomplete
+        if (!_allPlayerNames.contains(playerName)) {
+          _allPlayerNames.add(playerName);
+        }
+
         _stackControllers[playerName] = TextEditingController();
         _buyInControllers[playerName] = TextEditingController();
         _playerNameController.clear();


### PR DESCRIPTION
`ScoreInputScreen` で新規プレイヤーを追加する際に、その画面内で使用されるプレイヤー名のオートコンプリートリストが更新されない問題がありました。これにより、ユーザーがプレイヤーの追加が正しく機能していないと誤解する可能性がありました。

この修正では、`_addPlayer` メソッドを更新し、新しいプレイヤーが追加された際に `_allPlayerNames` リストにもその名前を追加するようにしました。これにより、UIのリアルタイム性が向上し、ユーザー体験が改善されます。