### PR TITLE
fix(score-input): Synchronize controllers to fix add player bug

### DIFF
--- a/lib/screens/score_input_screen.dart
+++ b/lib/screens/score_input_screen.dart
@@ -161,10 +161,13 @@ class _ScoreInputScreenState extends State<ScoreInputScreen> {
                         TextEditingController fieldController,
                         FocusNode fieldFocusNode,
                         VoidCallback onFieldSubmitted) {
-                      // Synchronize controllers
-                      if (_playerNameController != fieldController) {
-                        fieldController.text = _playerNameController.text;
+                      // When a player is added, _playerNameController is cleared.
+                      // We reflect that change in the fieldController here during the build.
+                      if (_playerNameController.text.isEmpty &&
+                          fieldController.text.isNotEmpty) {
+                        fieldController.clear();
                       }
+
                       return TextField(
                         controller: fieldController,
                         focusNode: fieldFocusNode,
@@ -172,6 +175,10 @@ class _ScoreInputScreenState extends State<ScoreInputScreen> {
                           labelText: 'Player Name',
                           border: OutlineInputBorder(),
                         ),
+                        onChanged: (text) {
+                          // Sync from the field's controller to our state's controller.
+                          _playerNameController.text = text;
+                        },
                         onSubmitted: (_) {
                           onFieldSubmitted();
                           _addPlayer();


### PR DESCRIPTION
The player name `TextField` was using a controller internal to the `Autocomplete` widget, while the 'Add' button was reading from a separate state controller. This caused a de-sync, preventing new players from being added.

This change fixes the issue by:
1.  Using the `onChanged` callback to keep the state controller updated with the text from the UI.
2.  Clearing the UI's text field after a player is successfully added by checking the state controller's value during the build phase.

This ensures the controllers are correctly synchronized, and the UI behaves as expected.